### PR TITLE
Add external configuration features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 !README.md
 !.gitignore
 !create-links.ps1
+!config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 !README.md
 !.gitignore
 !create-links.ps1
-!config.yaml

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,12 @@
+# Configuration structure
+# {Game ID}:
+#   title: {Game title}
+
+# Example
+# "70":
+#   title: Half-Life
+# "400":
+#   title: Portal
+
+# Write here the ones you would like to define
+

--- a/create-links.ps1
+++ b/create-links.ps1
@@ -138,6 +138,21 @@ function Set-ConfigToYaml {
     }
 }
 
+function Get-Game-Title {
+    param(
+        [string]$Id
+    )
+    $Result = Get-Game-Info -Id $Id
+
+    # $QueryGameTitle has double quotes to be removed
+    $QueryGameTitle = ([string]::Format('."{0}".data.name', $Id))
+    # Example: "Portal" -> Portal
+    $Title = ($Result.Content | jq $QueryGameTitle) -replace '"'
+    Write-Host "Game ID   : $Id"
+    Write-Host "Game title: $Title"
+    Return $Title
+}
+
 # Print parameters to console
 Write-Host "[inputs] Steam directory                     : $SteamDirectory"
 Write-Host "[inputs] Source screenshots directory        : $Source"
@@ -177,14 +192,9 @@ foreach ( $GameIdDirectory in Get-ChildItem $ResolvedSource ) {
 
     # Id Example: 400
     $Id = ($GameIdDirectory | Select-Object Name).Name
-    $Result = Get-Game-Info -Id $Id
 
-    # $QueryGameTitle has double quotes to be removed
-    $QueryGameTitle = ([string]::Format('."{0}".data.name', $Id))
-    # Example: "Portal" -> Portal
-    $Title = ($Result.Content | jq $QueryGameTitle) -replace '"'
-    Write-Host "Game ID   : $Id"
-    Write-Host "Game title: $Title"
+    # Title Example: Portal
+    $Title = Get-Game-Title -Id $Id
 
     # Remove invalid characters for a file name from title
     $SanitizedTitle = Get-SanitizedTitle -Title $Title

--- a/create-links.ps1
+++ b/create-links.ps1
@@ -63,7 +63,7 @@ function Get-SanitizedTitle {
 }
 
 # Retrieve game info such as title and banner image URL from Steam Web API
-function Get-Game-Info {
+function Get-GameInfo {
     param(
         [string] $Id
     )
@@ -138,7 +138,7 @@ function Set-ConfigToYaml {
     }
 }
 
-function Get-Game-Title {
+function Get-GameTitle {
     param(
         [string]$Id
     )
@@ -146,7 +146,7 @@ function Get-Game-Title {
         Write-Host ("Found a title in config. ID: ""$Id"" Title: {0}" -f $ParsedConfig[$Id]['title'].ToString())
         Return $ParsedConfig[$Id]['title']
     }
-    $Result = Get-Game-Info -Id $Id
+    $Result = Get-GameInfo -Id $Id
     # $QueryGameTitle has double quotes to be removed
     $QueryGameTitle = ([string]::Format('."{0}".data.name', $Id))
     # Example: "Portal" -> Portal
@@ -201,7 +201,7 @@ foreach ( $GameIdDirectory in Get-ChildItem $ResolvedSource ) {
     $Id = ($GameIdDirectory | Select-Object Name).Name
 
     # Title Example: Portal
-    $Title = Get-Game-Title -Id $Id
+    $Title = Get-GameTitle -Id $Id
 
     # Remove invalid characters for a file name from title
     $SanitizedTitle = Get-SanitizedTitle -Title $Title

--- a/create-links.ps1
+++ b/create-links.ps1
@@ -142,14 +142,21 @@ function Get-Game-Title {
     param(
         [string]$Id
     )
+    if ( $ParsedConfig.Contains($Id) -and $ParsedConfig[$Id].Contains('title') ) {
+        Write-Host ("Found a title in config. ID: ""$Id"" Title: {0}" -f $ParsedConfig[$Id]['title'].ToString())
+        Return $ParsedConfig[$Id]['title']
+    }
     $Result = Get-Game-Info -Id $Id
-
     # $QueryGameTitle has double quotes to be removed
     $QueryGameTitle = ([string]::Format('."{0}".data.name', $Id))
     # Example: "Portal" -> Portal
     $Title = ($Result.Content | jq $QueryGameTitle) -replace '"'
     Write-Host "Game ID   : $Id"
     Write-Host "Game title: $Title"
+    if ( -not $ParsedConfig.Contains($Id) ) {
+        $ParsedConfig[$Id] = @{}
+    }
+    $ParsedConfig[$Id]['title'] = $Title
     Return $Title
 }
 


### PR DESCRIPTION
### Description
Add external configuration features to specify arbitary game titles to game IDs.
When a game ID and a title is found in config, they are used for creating links, and no web request will be executed.

- Add `-Config` option
  - Specify a configuration file with this option
  - By default, `steam-shot-organizer/config.yaml` will be used
- Add `-OverwriteConfig` option
  - When it's enabled, a config file will be overwritten

```yaml
# Configuration structure
# {Game ID}:
#   title: {Game title}

# Example
"70":
  title: Half-Life
"400":
  title: Portal
```