### PR TITLE
Change symbolic links to shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 !LICENSE
 !README.md
 !.gitignore
-!create-links.ps1
+!create-shortcuts.ps1
 !convert-to-icon.ps1
 !set-icons.ps1
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,60 @@
 # steam-shot-organizer
-SteamShotOrganizer is PowerShell scripts for Windows to easily open Steam game screenshots folders without an official manager.  
-It aggregates screenshots from game directories into a single location while maintains the original files' integrity by using shortcuts.
+SteamShotOrganizer is a collection of PowerShell scripts for Windows to easily open Steam game screenshots folders without an official manager.
+It aggregates screenshots from screenshots directories into a single location while maintains the original files' integrity by using shortcuts.
+
+## Prerequisites (TBD)
+Some softwares have to be installed to run scripts.
+Since there are no dependency management tools, you need install them manually. I am sorry for that.
+
+```
+git clone https://github.com/LitMc/steam-shot-organizer.git
+cd steam-shot-organizer
+```
+
+## Run
+To run scripts, you have to launch a PowerShell console as Administrator because the scripts will modify Steam screenshots folders under a protected system directory.
+
+### Create shortcuts and retrieve game information
+```
+> .\create-shortcuts.ps1
+```
+
+### Convert images to icon (\*.ico) files
+```
+> .\convert-to-icons.ps1
+```
+
+### Set icons to the shortcuts
+```
+> .\set-icons.ps1
+```
+> [!CAUTION]
+> This script modifies system files like `desktop.ini` to customize icons of Steam screenshots folders.
+> If you have already modified `desktop.ini` of these folders, they are all overwritten by running `set-icons.ps1`.
+
+### Configuration
+You can define game titles and images for shortcuts in `config.yaml`.
+By default, the game name and image are taken from the Steam Web API or the local Steam library cache,
+If any of these are defined in `config.yaml`, they will take precedence.
+
+- You can use `config.yaml` to create shortcuts for 
+  - non-Steam games
+  - region exclusive games
+    - Web requests to Steam can be rejected
+
+```yaml
+# Structure of config.yaml
+{Game ID}:
+  title: {Game title}
+  image: {an image path for an icon}
+
+# Example
+"70":
+  title: Half-Life
+  image: "path\to\half-life.jpg"
+"400":
+  title: Portal
+  image: "path\to\portal-banner.png"
+
+# Write here the ones you would like to define
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # steam-shot-organizer
 SteamShotOrganizer is PowerShell scripts for Windows to easily open Steam game screenshots folders without an official manager.  
-It aggregates screenshots from game directories into a single location while maintains the original files' integrity by using symbolic links.  
+It aggregates screenshots from game directories into a single location while maintains the original files' integrity by using shortcuts.

--- a/convert-to-icon.ps1
+++ b/convert-to-icon.ps1
@@ -1,5 +1,5 @@
 param (
-    [string]$InputDirectory = (Join-Path $PSScriptRoot -ChildPath 'icon_source_images'),
+    [string]$InputDirectory = (Join-Path $PSScriptRoot -ChildPath 'images'),
     [string]$OutputDirectory = (Join-Path $PSScriptRoot -ChildPath 'icons'),
     [string]$Config = "$PSScriptRoot\config.yaml",
     [switch]$OverwriteIcon

--- a/create-shortcuts.ps1
+++ b/create-shortcuts.ps1
@@ -282,10 +282,10 @@ function Get-Image {
 }
 
 # Print parameters to console
-Write-Host "[inputs] Steam directory                     : $SteamDirectory"
-Write-Host "[inputs] Source screenshots directory        : $Source"
-Write-Host "[inputs] Destination symbolic links directory: $Destination"
-Write-Host "[inputs] ID:Title map config file            : $Config"
+Write-Host "[inputs] Steam directory                : $SteamDirectory"
+Write-Host "[inputs] Source screenshots directory   : $Source"
+Write-Host "[inputs] Destination shortcuts directory: $Destination"
+Write-Host "[inputs] ID:Title map config file       : $Config"
 
 # Load id:title mappings from a config yaml file
 $ParsedConfig = Get-ConfigFromYaml -Config $Config
@@ -338,10 +338,10 @@ foreach ( $GameIdDirectory in Get-ChildItem $ResolvedSource ) {
     # Get and test SourceScreenshotPath
     $SourceScreenshotPath = Get-SourceScreenshotPath -Id $Id -GameIdDirectory $GameIdDirectory
 
-    # Skip creating a symbolic link if a destination link already exists
+    # Skip creating a shortcuts if a destination link already exists
     $DestinationLinkPath = Join-Path -Path $Destination -ChildPath $SanitizedTitle
     if ( ( Test-Path -Path $DestinationLinkPath ) ) {
-        Write-Warning "A symbolic link ""$DestinationLinkPath"" already exists."
+        Write-Warning "A shortcuts ""$DestinationLinkPath"" already exists."
         if ( $OverwriteLink ) {
             Write-Host 'Overwrite a link with a new one.'
             Write-Host "Old source : ""$((Get-Item $DestinationLinkPath).LinkTarget)"""
@@ -356,7 +356,7 @@ foreach ( $GameIdDirectory in Get-ChildItem $ResolvedSource ) {
         Write-Host "Destination: $DestinationLinkPath"
     }
 
-    # Create a symbolic link
+    # Create a shortcuts
     if ( $OverwriteLink ) {
         $LinkResult = New-Item -ItemType SymbolicLink -Path $DestinationLinkPath -Target $SourceScreenshotPath -Force
     } else {
@@ -364,9 +364,9 @@ foreach ( $GameIdDirectory in Get-ChildItem $ResolvedSource ) {
     }
 
     if ( $LinkResult ) {
-        Write-Host "Create a symbolic link successfully: $DestinationLinkPath" -ForegroundColor DarkGreen
+        Write-Host "Create a shortcuts successfully: $DestinationLinkPath" -ForegroundColor DarkGreen
     } else {
-        Write-Error "Cannot create a symbolic link: $DestinationLinkPath"
+        Write-Error "Cannot create a shortcuts: $DestinationLinkPath"
         Write-Error "Please confirm the directory ""$Destination"" can be opened with Explorer."
         Exit-With-Error
     }

--- a/set-icons.ps1
+++ b/set-icons.ps1
@@ -110,12 +110,15 @@ Vid=
 
     Write-Host "Finished modifying ""$DesktopIniPath""."
 }
+Write-Host ''
 Write-Host 'Finished modifying desktop.ini of all screenshots folders.'
 
 $Prompt = @'
 To apply the changes, you must restart explorer.exe or your computer.
-Caution: When Explorer is restarted, all open file and folder windows will be closed.
-         Save all working data before restarting.
+
+Caution:
+When Explorer is restarted, all open file and folder windows will be closed.
+Save all working data before restarting.
 
 Do you want to restart explorer.exe? (y/N)
 '@


### PR DESCRIPTION
### Description
Since symbolic links have some troubles, I replaced symbolic links with shortcuts.

- Screenshots have advantage over symbolic links
  - Shortcuts icons follow changes in linked directories
  - When opened with Explorer, an original folder path is always displayed
